### PR TITLE
Fix: missing openai_api_base config

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -14,6 +14,7 @@ config_env = dotenv.dotenv_values(config_dir / "config.env")
 # config parameters
 telegram_token = config_yaml["telegram_token"]
 openai_api_key = config_yaml["openai_api_key"]
+openai_api_base = config_yaml.get("openai_api_base", None)
 use_chatgpt_api = config_yaml.get("use_chatgpt_api", True)
 allowed_telegram_usernames = config_yaml["allowed_telegram_usernames"]
 new_dialog_timeout = config_yaml["new_dialog_timeout"]

--- a/bot/openai_utils.py
+++ b/bot/openai_utils.py
@@ -3,6 +3,8 @@ import config
 import tiktoken
 import openai
 openai.api_key = config.openai_api_key
+if config.openai_api_base is not None:
+    openai.api_base = config.openai_api_base
 
 
 OPENAI_COMPLETION_OPTIONS = {

--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -1,5 +1,6 @@
 telegram_token: ""
 openai_api_key: ""
+openai_api_base: "http://api:8080/v1"  # Set the LocalAI API base or set null to use the OpenAI API
 use_chatgpt_api: true
 allowed_telegram_usernames: []  # if empty, the bot is available to anyone. pass a username string to allow it and/or user ids as positive integers and/or channel ids as negative integers
 new_dialog_timeout: 600  # new dialog starts after timeout (in seconds)


### PR DESCRIPTION
I tried to build a Telegram Bot with LocalAI, but the code is not working.
I found that the config `openai_api_base` is missing.
Add the config and tested the bot can run now.

Thanks.