### PR TITLE
Fix missing python requirement longcain-community

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ pymongo==4.3.3
 python-dotenv==0.21.0
 pydub==0.25.1
 langchain
+langchain-community
 openai
 chromadb
 pysqlite3-binary


### PR DESCRIPTION
Fixes the build step for the containers, that currently run into this error:
```
chatgpt_telegram_bot  | ModuleNotFoundError: Module langchain_community.embeddings not found. Please install langchain-community to access this module. You can install it using `pip install -U langchain-community`
```

reported as https://github.com/mudler/LocalAI/issues/2604