### PR TITLE
Remove entries with missing models from the config

### DIFF
--- a/config/models.yml
+++ b/config/models.yml
@@ -1,4 +1,4 @@
-available_text_models: ["gpt-3.5-turbo", "gpt-3.5-turbo-16k", "gpt-4", "text-davinci-003"]
+available_text_models: ["gpt-3.5-turbo", "gpt-4", "text-davinci-003"]
 
 info:
   gpt-3.5-turbo:


### PR DESCRIPTION
Removes GPT-16K and GTP-4 from the model menu available through /settings, reported in issue https://github.com/mudler/LocalAI/issues/2636